### PR TITLE
Escape HTML input

### DIFF
--- a/skybin.html
+++ b/skybin.html
@@ -23,7 +23,7 @@
       var blob = new Blob(
         [
           "<html><head><title>Welcome To Skybin</title><head><body><pre>" +
-          snippet +
+          snippet.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;") +
           "</pre></body></html>"
         ],
         { type: "text/html" }

--- a/skybin.html
+++ b/skybin.html
@@ -22,8 +22,13 @@
       button.classList.add("loading")
       var blob = new Blob(
         [
-          "<html><head><title>Welcome To Skybin</title><head><body><pre>" +
-          snippet.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;") +
+          "<html><head>" +
+          '<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>' +
+          "<title>Welcome To Skybin</title></head><body><pre>" +
+          // Escape HTML entities, including unicode and tags.
+          snippet.replace(/[\u00A0-\u9999<>\&]/g, function(i) {
+            return '&#'+i.charCodeAt(0)+';';
+          }) +
           "</pre></body></html>"
         ],
         { type: "text/html" }


### PR DESCRIPTION
**Latest version:** https://siasky.net/CAAx5PYMzk3bIgejm8yO_koV3Aavt2jJ96apKUa14U9p9g/

## About

Previously there was no escaping of any sort, so any HTML pasted by users would be part of the final HTML of the generated bin. Also, unicode was not properly escaped for HTML and did not display properly.

## Demonstration

**Before:** https://siasky.net/AABAcia96iFtA1bRJiDmfT7S_KBpor6-uFHsrxT9nGPpPA

**After:** https://siasky.net/AABn5fpuMH1Psv0mboMdwoGUx9aP1qKMAimOK7dFJGMzWQ